### PR TITLE
🐛 Fix Long Standing Shibboleth Header Missing Bug

### DIFF
--- a/nginx/nginx-conf/nginx.conf
+++ b/nginx/nginx-conf/nginx.conf
@@ -83,7 +83,7 @@ http {
         }
 
         # Allow Shibboleth to receive data when redirected to the callback URL.
-        location ~ /(dashboard/user/login.callback|oauth/shibcallback) {
+        location ~ /(dashboard/user/login.callback|oauth/shibcallback|settings/user/login.callback) {
             include shib_clear_headers;
             shib_request_use_headers on;
             shib_request /shibauthorizer;


### PR DESCRIPTION
Fixes the long standing shibboleth header missing bug when trying to login through the settings button on the home page.

Fixes https://github.com/uclapi/uclapi/issues/3235 and fixes https://github.com/uclapi/uclapi/issues/3072