### PR TITLE
WIP: Generate HTTPS certs using Certbot

### DIFF
--- a/nginx.Dockerfile
+++ b/nginx.Dockerfile
@@ -35,7 +35,11 @@ RUN apt-get update && \
                        sed \
                        git \
                        gnupg && \
-    apt-get clean
+    apt-get clean && \
+    snap install core && \
+    snap refresh core && \
+    snap install --classic certbot && \
+    ln -s /snap/bin/certbot /usr/bin/certbot
 
 # Installing Nginx
 ENV NGINX_AWS_URL https://${AWS_BUCKET}.s3.amazonaws.com/nginx

--- a/nginx/nginx-conf/nginx.conf
+++ b/nginx/nginx-conf/nginx.conf
@@ -22,10 +22,15 @@ http {
 
     keepalive_timeout  65;
 
-    # Listen on all URLs and redirect them to 
+    # Listen on all URLs and redirect them to
     server {
         listen       80;
         server_name  _;
+
+        location '/.well-known/acme-challenge' {
+            default_type "text/plain";
+            root /var/www/letsencrypt;
+        }
 
         #access_log  logs/host.access.log  main;
         location / {
@@ -53,8 +58,9 @@ http {
         listen       443 ssl;
         server_name  SERVER_NAME_HERE;
 
-        ssl_certificate      /web/internal-cert/cert.pem;
-        ssl_certificate_key  /web/internal-cert/key.pem;
+        ssl_certificate         /etc/letsencrypt/live/uclapi-rsa/fullchain.pem;
+        ssl_certificate_key     /etc/letsencrypt/live/uclapi-rsa/privkey.pem;
+        ssl_trusted_certificate /etc/letsencrypt/live/uclapi-rsa/chain.pem;
 
         ssl_session_cache    shared:SSL:1m;
         ssl_session_timeout  5m;

--- a/nginx/run.sh
+++ b/nginx/run.sh
@@ -1,5 +1,32 @@
 #!/bin/bash
+
+# Certbot env setup
+if [ ${ENVIRONMENT} = "prod" ]; then
+    certbot_hostname="uclapi.com"
+else
+    certbot_hostname="staging.ninja"
+fi
+
+if [ ${DRYRUN} = "1" ]; then
+    letsencrypt_url="https://acme-staging-v02.api.letsencrypt.org/directory"
+else
+    letsencrypt_url="https://acme-v02.api.letsencrypt.org/directory"
+fi
+
 while /bin/true; do
+    # Certbot setup modified from docker-nginx-certbot
+    # https://github.com/JonasAlfredsson/docker-nginx-certbot/blob/b119b10640c1a19bbba7a40fd13ab4e14d801ee5/src/scripts/run_certbot.sh#L52-L66
+    # Certbot will write certificates to/etc/letsencrypt/live/uclapi-rsa/
+    # See nginx.conf for the actual use of the certificates
+    certbot certonly --agree-tos --keep --noninteractive \
+        --authenticator webroot --webroot-path=/var/www/letsencrypt \
+        --preferred-challenges http-01 \
+        --email "isd.apiteam@ucl.ac.uk" \
+        --server "${letsencrypt_url}" \
+        --key-type "rsa" \
+        --cert-name "uclapi-rsa" \
+        --domains ${certbot_hostname}
+
     # Ensure Supervisor is alive first
     ps aux | grep supervisor | grep -q -v grep
     SUPERVISOR_STATUS=$?


### PR DESCRIPTION
A lot of this has come from github.com/JonasAlfredsson/docker-nginx-certbot/:

- Update NGINX Dockerfile to install certbot via Snap, following these instructions: https://certbot.eff.org/lets-encrypt/ubuntufocal-nginx
- Update NGINX config to use certificates from letsencrypt output dir
- Update NGINX config to allow `/.well-known/acme-challenge requests` and route to letsencrypt directory
- Update run.sh to call `certbot` to generate/renew certificates -- note this loops every 60 seconds; maybe we want to increase the interval?